### PR TITLE
Add Linux 64-bit build compatibility

### DIFF
--- a/FT2232c.cpp
+++ b/FT2232c.cpp
@@ -176,7 +176,7 @@ FTC_STATUS FT2232c::FTC_IsDeviceFT2232CType(FT_DEVICE_LIST_INFO_NODE devInfo, LP
   if (devInfo.Type == FT_DEVICE_2232C)
   {
     // Search for the last occurrence of the channel string ie ' A'. The Description field contains the device name
-    if ((pszStringSearch = strstr(strupr(devInfo.Description), DEVICE_CHANNEL_A)) != NULL)
+    if ((pszStringSearch = strstr(strupr((char*)devInfo.Description), DEVICE_CHANNEL_A)) != NULL)
     {
       // Ensure the last two characters of the device name is ' A' ie channel A
       if (strlen(pszStringSearch) == 2)
@@ -384,7 +384,7 @@ FTC_STATUS FT2232c::FTC_OpenSpecifiedDevice(LPSTR lpDeviceName, DWORD dwLocation
 
           if (Status == FTC_SUCCESS)
           {
-            *pftHandle = (DWORD)reinterpret_cast<intptr_t>(ftHandle);
+            *pftHandle = (uintptr_t)ftHandle;
 
             FTC_InsertDeviceHandle(lpDeviceName, dwLocationID, *pftHandle);
           }
@@ -502,7 +502,7 @@ FTC_STATUS FT2232c::FTC_IsDeviceHandleValid(FTC_HANDLE ftHandle)
   INT iDeviceCntr = 0;
   BOOLEAN bDevicempHandleFound = false;
 
-  if ((uiNumOpenedDevices > 0) && (ftHandle > 0))
+  if ((uiNumOpenedDevices > 0) && (ftHandle != 0))
   {
     dwProcessId = GetCurrentProcessId();
 

--- a/FT2232c.h
+++ b/FT2232c.h
@@ -31,7 +31,7 @@ Revision History:
 #include <ftd2xx.h>
 #include "FtcJtagInternal.h"
 
-typedef DWORD FTC_HANDLE;
+typedef uintptr_t FTC_HANDLE;
 typedef ULONG FTC_STATUS;
 
 #define FTC_SUCCESS 0  //FTC_OK
@@ -58,7 +58,7 @@ typedef struct Ft_Device_Data{
 	DWORD dwProcessId;					                      // process identifier of the calling process ie application
   char  szDeviceName[MAX_NUM_DEVICE_NAME_CHARS];    // pointer to the name of a FT2232C dual type device
   DWORD dwLocationID;                               // the location identifier of a FT2232C dual type device
-  DWORD hDevice;                                    // handle to the opened and initialized FT2232C dual type device
+  FTC_HANDLE hDevice;                               // handle to the opened and initialized FT2232C dual type device
 }FTC_DEVICE_DATA, *PFTC_DEVICE_DATA;
 
 typedef DWORD FT2232CDeviceIndexes[MAX_NUM_DEVICES];

--- a/FT2232h.cpp
+++ b/FT2232h.cpp
@@ -173,8 +173,8 @@ FTC_STATUS FT2232h::FTC_IsDeviceHiSpeedType(FT_DEVICE_LIST_INFO_NODE devInfo, LP
   if ((devInfo.Type == FT_DEVICE_2232H) || (devInfo.Type == FT_DEVICE_4232H))
   {
     // Search for the first occurrence of the channel string ie ' A' or ' B'. The Description field contains the device name
-    if (((pszStringSearch = strstr(strupr(devInfo.Description), DEVICE_NAME_CHANNEL_A)) != NULL) ||
-        ((pszStringSearch = strstr(strupr(devInfo.Description), DEVICE_NAME_CHANNEL_B)) != NULL))
+    if (((pszStringSearch = strstr(strupr((char*)devInfo.Description), DEVICE_NAME_CHANNEL_A)) != NULL) ||
+        ((pszStringSearch = strstr(strupr((char*)devInfo.Description), DEVICE_NAME_CHANNEL_B)) != NULL))
     {
       // Ensure the last two characters of the device name is ' A' ie channel A or ' B' ie channel B
       if (strlen(pszStringSearch) == 2)
@@ -427,7 +427,7 @@ FTC_STATUS FT2232h::FTC_OpenSpecifiedHiSpeedDevice(LPSTR lpDeviceName, DWORD dwL
           {
             if ((Status = FT_OpenEx((PVOID)dwLocationID, FT_OPEN_BY_LOCATION, &ftHandle)) == FTC_SUCCESS)
             {
-              *pftHandle = (DWORD)reinterpret_cast<intptr_t>(ftHandle);
+              *pftHandle = (uintptr_t)ftHandle;
 
               FTC_InsertDeviceHandle(lpDeviceName, dwLocationID, lpChannel, dwDeviceType, *pftHandle);
             }
@@ -508,7 +508,7 @@ FTC_STATUS FT2232h::FTC_IsHiSpeedDeviceHandleValid(FTC_HANDLE ftHandle)
   INT iDeviceCntr = 0;
   bool bDevicempHandleFound = false;
 
-  if ((uiNumOpenedHiSpeedDevices > 0) && (ftHandle > 0))
+  if ((uiNumOpenedHiSpeedDevices > 0) && (ftHandle != 0))
   {
     dwProcessId = GetCurrentProcessId();
 

--- a/FT2232h.h
+++ b/FT2232h.h
@@ -32,7 +32,7 @@ Revision History:
 #include "FT2232c.h"
 #include <ftd2xx.h>
 
-typedef DWORD FTC_HANDLE;
+typedef uintptr_t FTC_HANDLE;
 typedef ULONG FTC_STATUS;
 
 #define FTC_SUCCESS 0  //FTC_OK
@@ -58,7 +58,7 @@ typedef struct Ft_Hi_Speed_Device_Data{
   char  szChannel[MAX_NUM_CHANNEL_CHARS];           // the channel ie A or B of a FT2232H or FT4232H hi-speed device
   BOOL  bDivideByFiveClockingState;                 // contains the state of the clock divide by five ie turned on(TRUE), turned off(FALSE)
   DWORD dwDeviceType;                               // hi-speed device type, FT2232H or FT4232H
-  DWORD hDevice;                                    // handle to the opened and initialized FT2232H or FT4232H hi-speed device
+  FTC_HANDLE hDevice;                               // handle to the opened and initialized FT2232H or FT4232H hi-speed device
 }FTC_HI_SPEED_DEVICE_DATA, *PFTC_HI_SPEED_DEVICE_DATA;
 
 typedef DWORD HiSpeedDeviceIndexes[MAX_NUM_DEVICES];

--- a/FT2232hMpsseJtag.cpp
+++ b/FT2232hMpsseJtag.cpp
@@ -1525,7 +1525,7 @@ void FT2232hMpsseJtag::DeleteDeviceCommandsSequenceDataBuffers(FTC_HANDLE ftHand
     {
       bDeviceHandleFound = true;
 
-      OpenedDevicesCommandsSequenceData[dwDeviceIndex].hDevice = 0;
+    OpenedDevicesCommandsSequenceData[dwDeviceIndex].hDevice = 0;
       OpenedDevicesCommandsSequenceData[dwDeviceIndex].dwNumBytesToSend = 0;
       pCmdsSequenceDataOutPutBuffer = OpenedDevicesCommandsSequenceData[dwDeviceIndex].pCommandsSequenceDataOutPutBuffer;
       delete [] pCmdsSequenceDataOutPutBuffer;

--- a/FT2232hMpsseJtag.h
+++ b/FT2232hMpsseJtag.h
@@ -188,7 +188,7 @@ typedef PReadCommandSequenceData ReadCommandsSequenceData[1];
 typedef ReadCommandsSequenceData *PReadCommandsSequenceData;
 
 typedef struct Ft_Device_Cmd_Sequence_Data{
-  DWORD hDevice;                                    // handle to the opened and initialized FT2232C dual type device
+  FTC_HANDLE hDevice;                               // handle to the opened and initialized FT2232C dual type device
   DWORD dwNumBytesToSend;
   POutputByteBuffer pCommandsSequenceDataOutPutBuffer;
   DWORD dwSizeReadCommandsSequenceDataBuffer;

--- a/ftcjtag.h
+++ b/ftcjtag.h
@@ -34,6 +34,7 @@ Revision History:
 #else
    #include "WinTypes.h"
 #endif
+#include <stdint.h>
 
 // The following ifdef block is the standard way of creating macros
 // which make exporting from a DLL simpler.  All files within this DLL
@@ -53,7 +54,7 @@ Revision History:
    #define FTCJTAG_API __attribute__((visibility ("default")))
 #endif
 
-typedef DWORD FTC_HANDLE;
+typedef uintptr_t FTC_HANDLE;
 typedef ULONG FTC_STATUS;
 
 // Hi-speed device types

--- a/ftd2xx.h
+++ b/ftd2xx.h
@@ -1,0 +1,58 @@
+#ifndef FTD2XX_H
+#define FTD2XX_H
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void* FT_HANDLE;
+typedef void* PVOID;
+typedef const char* LPCSTR;
+typedef void* LPVOID;
+typedef BYTE* LPBYTE;
+typedef ULONG* PULONG;
+typedef DWORD* LPDWORD;
+typedef WORD* LPWORD;
+typedef UCHAR* PUCHAR;
+
+typedef struct _FT_DEVICE_LIST_INFO_NODE {
+    DWORD Flags;
+    DWORD Type;
+    DWORD ID;
+    DWORD LocId;
+    CHAR SerialNumber[16];
+    CHAR Description[64];
+    FT_HANDLE ftHandle;
+} FT_DEVICE_LIST_INFO_NODE, *PFT_DEVICE_LIST_INFO_NODE;
+
+#define FT_DEVICE_2232C 4
+#define FT_DEVICE_2232H 6
+#define FT_DEVICE_4232H 7
+
+#define FT_OPEN_BY_LOCATION 0x0002
+
+#define FT_OK 0
+
+DWORD FT_OpenEx(PVOID pArg1, DWORD Flags, FT_HANDLE *pHandle);
+DWORD FT_Close(FT_HANDLE handle);
+DWORD FT_Write(FT_HANDLE handle, LPVOID buffer, DWORD size, LPDWORD written);
+DWORD FT_Read(FT_HANDLE handle, LPVOID buffer, DWORD size, LPDWORD read);
+DWORD FT_ResetDevice(FT_HANDLE handle);
+DWORD FT_GetQueueStatus(FT_HANDLE handle, LPDWORD rxBytes);
+DWORD FT_SetUSBParameters(FT_HANDLE handle, DWORD inSize, DWORD outSize);
+DWORD FT_SetChars(FT_HANDLE handle, UCHAR EventChar, UCHAR EventCharEnabled,
+                  UCHAR ErrorChar, UCHAR ErrorCharEnabled);
+DWORD FT_SetTimeouts(FT_HANDLE handle, DWORD readTimeout, DWORD writeTimeout);
+DWORD FT_SetLatencyTimer(FT_HANDLE handle, UCHAR latency);
+DWORD FT_GetLatencyTimer(FT_HANDLE handle, PUCHAR latency);
+DWORD FT_SetBitMode(FT_HANDLE handle, UCHAR mask, UCHAR enable);
+DWORD FT_CreateDeviceInfoList(LPDWORD numDevs);
+DWORD FT_GetDeviceInfoList(PFT_DEVICE_LIST_INFO_NODE list, LPDWORD numDevs);
+DWORD FT_GetDeviceInfoDetail(DWORD index, LPDWORD flags, LPDWORD type, LPDWORD id,
+                             LPDWORD locId, LPVOID serial, LPVOID desc, FT_HANDLE *handle);
+DWORD FT_GetDeviceInfo(FT_HANDLE handle, LPDWORD type, LPDWORD id,
+                       char* serial, char* desc, PVOID dummy);
+#ifdef __cplusplus
+}
+#endif
+#endif // FTD2XX_H


### PR DESCRIPTION
## Summary
- widen FTC_HANDLE to use `uintptr_t`
- adjust handle comparisons and casts for 64-bit pointers
- create minimal `ftd2xx.h` stub for Linux builds
- add casts for `devInfo.Description`

## Testing
- `cmake .. -DFTD2XX_INCLUDE_DIR=..`
- `make`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684089c558d48320af588efff0d64a6d